### PR TITLE
Pin automatic backport Github action in CI/CD chain to version 1.1.0

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -11,6 +11,6 @@ jobs:
     name: Backport
     steps:
       - name: Backport
-        uses: tibdex/backport@v1
+        uses: tibdex/backport@v1.1.0
         with:
           github_token: ${{ secrets.PERSONAL_TOKEN }}


### PR DESCRIPTION
If commits from a pull request are backported to stable branches the backporting fails. This patch pins the backport Github action to an older working version, since the latest version (1.1.1) does not work properly.

This patch fixes #65.